### PR TITLE
Fix fs mocking

### DIFF
--- a/packages/wdio-cli/src/commands/install.js
+++ b/packages/wdio-cli/src/commands/install.js
@@ -38,14 +38,18 @@ export async function handler(argv) {
      */
     const { type, name, npm } = argv
 
-    // verify for supported types via `supportedInstallations` keys
+    /**
+     * verify for supported types via `supportedInstallations` keys
+     */
     if (!Object.keys(supportedInstallations).includes(type)) {
         console.log(`Type ${type} is not supported.`)
         process.exit(0)
         return
     }
 
-    // verify if the name of the `type` is valid
+    /**
+     * verify if the name of the `type` is valid
+     */
     if (!supportedInstallations[type].find(pkg => pkg.short === name)) {
         console.log(`${name} is not a supported ${type}.`)
         process.exit(0)
@@ -53,7 +57,6 @@ export async function handler(argv) {
     }
 
     const localConfPath = path.join(process.cwd(), 'wdio.conf.js')
-
     if (!fs.existsSync(localConfPath)) {
         try {
             await missingConfigurationPrompt('install', `
@@ -66,7 +69,6 @@ You can create one by running 'wdio config'`)
     }
 
     const configFile = fs.readFileSync(localConfPath, { encoding: 'UTF-8' })
-
     const match = findInConfig(configFile, type)
 
     if (match && match[0].includes(name)) {
@@ -90,12 +92,10 @@ You can create one by running 'wdio config'`)
     }
 
     console.log(`Package "${selectedPackage.package}" installed successfully.`)
-
     const newConfig = replaceConfig(configFile, type, name)
-
     fs.writeFileSync(localConfPath, newConfig, { encoding: 'utf-8' })
-
     console.log('Your wdio.conf.js file has been updated.')
+
     process.exit(0)
 }
 /* eslint-enable no-console */

--- a/packages/wdio-cli/src/utils/index.js
+++ b/packages/wdio-cli/src/utils/index.js
@@ -118,24 +118,21 @@ export function findInConfig(config, type) {
     }
 
     const regex = new RegExp(regexStr, 'gmi')
-
     return config.match(regex)
 }
 
-export function replaceConfig(
-    config,
-    type,
-    name
-) {
+export function replaceConfig(config, type, name) {
     const match = findInConfig(config, type)
-    if (match && match.length) {
-        if (type === 'framework') {
-            return buildNewConfigString(config, type, name)
-        }
-        const text = match.pop()
-
-        return config.replace(text, buildNewConfigArray(text, type, name))
+    if (!match || match.length === 0) {
+        return
     }
+
+    if (type === 'framework') {
+        return buildNewConfigString(config, type, name)
+    }
+    const text = match.pop()
+
+    return config.replace(text, buildNewConfigArray(text, type, name))
 }
 
 export function addServiceDeps(names, packages, update) {

--- a/packages/wdio-sync/src/executeHooksWithArgs.js
+++ b/packages/wdio-sync/src/executeHooksWithArgs.js
@@ -13,7 +13,7 @@ const log = logger('@wdio/sync')
  * @return {Promise}  promise that gets resolved once all hooks finished running
  */
 /* istanbul ignore next */
-export default function executeHooksWithArgs (hooks = [], args) {
+export default function executeHooksWithArgs (hooks, args) {
     /**
      * make sure hooks are an array of functions
      */

--- a/packages/wdio-sync/src/fibers.js
+++ b/packages/wdio-sync/src/fibers.js
@@ -9,7 +9,7 @@ global._HAS_FIBER_CONTEXT = false
 
 const origErrorFn = ::console.error
 const errors = []
-console.error = (...args) => errors.push(args)
+console.error = /* istanbul ignore next */ (...args) => errors.push(args)
 
 /**
  * Helper method to retrieve a version of `fibers` for your Node version.

--- a/packages/wdio-sync/tests/executeHooksWithArgs.test.js
+++ b/packages/wdio-sync/tests/executeHooksWithArgs.test.js
@@ -1,0 +1,36 @@
+import Fiber from '../src/fibers'
+
+import executeHooksWithArgs from '../src/executeHooksWithArgs'
+
+const hookError = new Error('oops')
+const hook1 = jest.fn().mockImplementation(
+    (...args) => new Promise(
+        (resolve) => setTimeout(
+            () => resolve(args.join('_')), 50)))
+const hook2 = jest.fn().mockImplementation(() => { throw hookError })
+const hook3 = jest.fn().mockReturnValue('3_2_1')
+const hook4 = jest.fn().mockReturnValue(Promise.reject(hookError))
+
+beforeEach(() => {
+    hook1.mockClear()
+    hook2.mockClear()
+    hook3.mockClear()
+    hook4.mockClear()
+    Fiber.mockClear()
+})
+
+test('runs all hooks', async () => {
+    const result = await executeHooksWithArgs(
+        [hook1, hook2, hook3, hook4],
+        [1, 2, 3]
+    )
+
+    expect(result).toEqual(['1_2_3', hookError, '3_2_1', hookError])
+    expect(Fiber).toBeCalledTimes(4)
+})
+
+test('allows execution with single hook and argument', async () => {
+    const result = await executeHooksWithArgs(hook1, 'foobar')
+    expect(result).toEqual(['foobar'])
+    expect(Fiber).toBeCalledTimes(1)
+})


### PR DESCRIPTION
## Proposed changes

As I was wondering why you had the issue with the snapshots I remembered that Jest probably has to do with it and looked into the test to find the place where `fs` is being mocked. I fixed it so that Jest doesn't use mocks anymore.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
